### PR TITLE
Add Tesla middleware

### DIFF
--- a/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -1,0 +1,9 @@
+defmodule Tesla.Middleware.OpenTelemetry do
+  @behaviour Tesla.Middleware
+
+  def call(env, next, _options) do
+    env
+    |> Tesla.put_headers(:otel_propagator.text_map_inject([]))
+    |> Tesla.run(next)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryTesla.MixProject do
   def project do
     [
       app: :opentelemetry_tesla,
-      version: "1.0.0-rc.1",
+      version: "1.1.0-rc.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -1,0 +1,26 @@
+defmodule Tesla.Middleware.OpenTelemetryTest do
+  use ExUnit.Case
+
+  test "Injects distributed tracing headers" do
+    OpentelemetryTelemetry.start_telemetry_span(
+      "tracer_id",
+      "my_label",
+      %{},
+      %{kind: :client}
+    )
+
+    assert {:ok,
+            %Tesla.Env{
+              headers: [
+                {"traceparent", traceparent}
+              ]
+            }} =
+              Tesla.Middleware.OpenTelemetry.call(
+               %Tesla.Env{url: ""},
+               [],
+               "http://example.com"
+             )
+
+    assert is_binary(traceparent)
+  end
+end


### PR DESCRIPTION
This Tesla middleware injects tracing headers into HTTP requests so that we get distributed tracing for free.