### PR TITLE
Fix test errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,0 @@
-import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,0 @@
-import Config
-
-config :opentelemetry,
-  sampler: {:otel_sampler_always_on, %{}},
-  tracer: :otel_tracer_default,
-  processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]

--- a/test/opentelemetry_tesla_test.exs
+++ b/test/opentelemetry_tesla_test.exs
@@ -13,7 +13,12 @@ defmodule OpentelemetryTeslaTest do
   setup do
     bypass = Bypass.open()
 
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    :application.stop(:opentelemetry)
+    :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
+    :application.set_env(:opentelemetry, :processors, [
+      {:otel_batch_processor, %{scheduled_delay_ms: 1, exporter: {:otel_exporter_pid, self()}}}
+    ])
+    :application.start(:opentelemetry)
 
     OpentelemetryTesla.setup()
 


### PR DESCRIPTION
We got
```
10:00:00.917 [warn]  Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'

10:00:00.952 [info]  client error exporting spans {:failed_connect,
 [{:to_address, {'localhost', 4317}}, {:inet, [:inet], :econnrefused}]}
```
previously.

I changed the test setup to set up `otel_exporter_pid` immediately which
seemed to remove exporter related errors/warnings.