### PR TITLE
Fix encoding query that includes arrays

### DIFF
--- a/lib/opentelemetry_tesla.ex
+++ b/lib/opentelemetry_tesla.ex
@@ -127,15 +127,12 @@ defmodule OpentelemetryTesla do
            query: query
          }
        }) do
-    uri =
-      query
-      |> Enum.into(%{})
-      |> URI.encode_query()
-      |> build_full_uri(url)
+    url = Tesla.build_url(url, query)
+    uri = URI.parse(url)
 
     attrs = [
       "http.method": http_method(method),
-      "http.url": URI.to_string(uri),
+      "http.url": url,
       "http.target": uri.path,
       "http.host": uri.host,
       "http.scheme": uri.scheme,
@@ -143,14 +140,6 @@ defmodule OpentelemetryTesla do
     ]
 
     maybe_append_content_length(attrs, headers)
-  end
-
-  defp build_full_uri("", url) do
-    URI.parse(url)
-  end
-
-  defp build_full_uri(query_string, url) do
-    URI.parse("#{url}?#{query_string}")
   end
 
   defp maybe_append_content_length(attrs, headers) do

--- a/test/opentelemetry_tesla_test.exs
+++ b/test/opentelemetry_tesla_test.exs
@@ -140,7 +140,7 @@ defmodule OpentelemetryTeslaTest do
           {Tesla.Middleware.BaseUrl, url},
           Tesla.Middleware.Telemetry,
           Tesla.Middleware.PathParams,
-          {Tesla.Middleware.Query, [token: "some-token"]}
+          {Tesla.Middleware.Query, [token: "some-token", array: ["foo", "bar"]]}
         ]
 
         Tesla.client(middleware)
@@ -158,7 +158,7 @@ defmodule OpentelemetryTeslaTest do
     assert_receive {:span, span(name: "HTTP GET", attributes: attributes)}
 
     assert attributes[:"http.url"] ==
-             "http://localhost:#{bypass.port}/users/2?token=some-token"
+             "http://localhost:#{bypass.port}/users/2?token=some-token&array%5B%5D=foo&array%5B%5D=bar"
   end
 
   test "http.url attribute is correct when request doesn't contain query string parameters", %{


### PR DESCRIPTION
`URI.encode_query` does not handle queries that include queries. Tesla
however supports these. Instead of `URI.encode_query` we can use
`Tesla.build_url`.