### PR TITLE
Don't put method in span name for non-default case

### DIFF
--- a/lib/middleware/opentelemetry_tesla_middleware.ex
+++ b/lib/middleware/opentelemetry_tesla_middleware.ex
@@ -17,7 +17,7 @@ defmodule Tesla.Middleware.OpenTelemetry do
   defp get_span_name(env) do
     case env.opts[:path_params] do
       nil -> "HTTP #{http_method(env.method)}"
-      _ -> "#{http_method(env.method)} #{URI.parse(env.url).path}"
+      _ -> URI.parse(env.url).path
     end
   end
 

--- a/test/middleware/opentelemetry_tesla_middleware_test.exs
+++ b/test/middleware/opentelemetry_tesla_middleware_test.exs
@@ -56,7 +56,7 @@ defmodule Tesla.Middleware.OpenTelemetryTest do
     |> TestClient.client()
     |> TestClient.get()
 
-    assert_receive {:span, span(name: "GET /users/:id", attributes: attributes)}
+    assert_receive {:span, span(name: "/users/:id", attributes: _attributes)}
   end
 
   test "Records spans for Tesla HTTP client", %{bypass: bypass} do


### PR DESCRIPTION
I missed this in the original PR review. The method should only go in the span name when we can't establish the parameterized name.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client-server-example