### PR TITLE
`:span_name` and `:non_error_statuses` opts

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,6 @@ defmodule OpentelemetryTesla.MixProject do
         "OpenTelemetry.io" => "https://opentelemetry.io"
       }
     ]
-    ]
   end
 
   # Run "mix help compile.app" to learn about applications.


### PR DESCRIPTION
Hello @ricardoccpaiva and maintainers

could you please consider this PR that brings two optional arguments to the middleware:
- `:span_name` (allows to provide an arbitrary span name)
- `:non_error_statuses` (allows to specify a list of http statuses that won't be considered as error even when they >= 400)